### PR TITLE
Improve search flow

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,13 @@
 {
-    "cSpell.words": [
-        "pokemons"
-    ],
-    "editor.formatOnSave": true
+  "cSpell.words": ["pokemons"],
+  "editor.formatOnSave": true,
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
 }

--- a/app/components/ui/pokemonSearchBar.tsx
+++ b/app/components/ui/pokemonSearchBar.tsx
@@ -1,0 +1,35 @@
+import { Form, useSearchParams, type HTMLFormMethod } from 'react-router';
+import { Input } from './input';
+import { Button } from './button';
+
+type PokemonSearchBarParams = {
+  method?: HTMLFormMethod;
+  action: string;
+};
+
+export default function PokemonSearchBar({
+  method = 'GET',
+  action,
+}: PokemonSearchBarParams) {
+  const [searchParams] = useSearchParams();
+  const q = searchParams.get('q') || '';
+  return (
+    <Form
+      method={method}
+      action={action}
+      className="flex w-full justify-center max-w-xl px-8 gap-2"
+    >
+      <Input
+        key={q}
+        aria-label="Search pokemon by name or id"
+        id="q"
+        name="q"
+        type="search"
+        placeholder="Pikachu"
+        className="w-full"
+        defaultValue={q}
+      />
+      <Button type="submit">Search</Button>
+    </Form>
+  );
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -9,7 +9,7 @@ export default [
   layout('components/authWrapper.tsx', [
     route('/', 'routes/home/home.tsx', [
       index('routes/home/pokemonList.tsx'),
-      route('/pokemon/:name', 'routes/home/pokemonDialog.tsx'),
+      route('/pokemon', 'routes/home/pokemon.tsx'),
     ]),
   ]),
   route('/login', 'routes/login.tsx'),

--- a/app/routes/home/home.tsx
+++ b/app/routes/home/home.tsx
@@ -1,36 +1,11 @@
-import { Outlet, useFetcher } from 'react-router';
+import { Outlet, useNavigation } from 'react-router';
 import PokeballIcon from '~/assets/pokeball.svg';
-import { Button } from '~/components/ui/button';
-import { Input } from '~/components/ui/input';
-import type { Route } from './+types/home';
-import { wait } from '~/lib/utils';
-import { getPokemon } from '~/services/apiClient';
-
-export async function clientAction({ request }: Route.ClientActionArgs) {
-  let formData = await request.formData();
-  const searchTerm = String(formData.get('search'));
-
-  if (!searchTerm) {
-    return [];
-  }
-
-  try {
-    // delay request so we can see Loading state. Just for demo purposes
-    await wait(2000);
-    const pokemon = await getPokemon(searchTerm);
-
-    return [pokemon];
-  } catch (error) {
-    return [];
-  }
-}
-
-export const SEARCH_POKEMON_FORM_KEY = 'searchPokemon';
+import Loading from '~/components/ui/Loading';
+import PokemonSearchBar from '~/components/ui/pokemonSearchBar';
 
 export default function Home() {
-  const fetcher = useFetcher<typeof clientAction>({
-    key: SEARCH_POKEMON_FORM_KEY,
-  });
+  const { state } = useNavigation();
+  const shouldShowLoading = state === 'loading' || state === 'submitting';
 
   return (
     <main className="flex items-center justify-center pt-16 pb-4">
@@ -39,21 +14,9 @@ export default function Home() {
           <h1 className="text-5xl">Pokeapp</h1>
           <img src={PokeballIcon} alt="Pokeapp icon" className="w-16" />
         </header>
-        <fetcher.Form
-          method="post"
-          className="flex w-full justify-center max-w-xl px-8 gap-2"
-        >
-          <Input
-            id="search"
-            name="search"
-            type="search"
-            placeholder="Pikachu"
-            className="w-full"
-          />
-          <Button type="submit">Search</Button>
-        </fetcher.Form>
+        <PokemonSearchBar action="/pokemon" />
         <div className="grid content-center items-center min-h-80">
-          <Outlet />
+          {shouldShowLoading ? <Loading /> : <Outlet />}
         </div>
       </div>
     </main>

--- a/app/routes/home/pokemon.tsx
+++ b/app/routes/home/pokemon.tsx
@@ -6,48 +6,60 @@ import {
 } from '~/components/ui/dialog';
 import { Badge } from '~/components/ui/badge';
 import { data, useLoaderData, useNavigate } from 'react-router';
-import type { Route } from './+types/pokemonDialog';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs';
 import { getPokemon } from '~/services/apiClient';
+import { wait } from '~/lib/utils';
+import type { Route } from './+types/pokemon';
 
-export async function clientLoader({ params }: Route.ClientLoaderArgs) {
+export async function clientLoader({ request }: Route.ClientLoaderArgs) {
+  const url = new URL(request.url);
+  const searchTerm = url.searchParams.get('q');
+
+  if (!searchTerm) {
+    return null;
+  }
+
   try {
-    const resp = await getPokemon(params.name);
-    return resp;
+    // delay request so we can see Loading state. Just for demo purposes
+    await wait(1000);
+    const pokemon = await getPokemon(searchTerm);
+    return pokemon;
   } catch (error) {
-    throw data(
-      { message: `Pokemon Not Found for search name/id ${params.name}` },
-      { status: 404 }
-    );
+    return {
+      error: `Pokemon "${searchTerm}" not found. Try searching with a different term`,
+    };
   }
 }
 
-export default function PokemonDialog() {
-  const pokemon = useLoaderData<typeof clientLoader>();
-  const navigate = useNavigate();
+export default function Pokemon() {
+  const data = useLoaderData<typeof clientLoader>();
 
-  function handleOpenChange() {
-    return navigate(-1);
+  if (!data) {
+    return null;
+  }
+
+  if ('error' in data) {
+    return <p>{data.error}</p>;
   }
 
   return (
-    <Dialog defaultOpen onOpenChange={handleOpenChange}>
+    <Dialog defaultOpen>
       <DialogContent
         className="w-80"
-        aria-description={`Detail view for "${pokemon.name}" pokemon`}
+        aria-description={`Detail view for "${data.name}" pokemon`}
       >
         <DialogHeader>
-          <DialogTitle className="text-center">{pokemon.name}</DialogTitle>
+          <DialogTitle className="text-center">{data.name}</DialogTitle>
         </DialogHeader>
         <div className="flex flex-col gap-8">
           <div className="flex justify-center h-48">
             <img
               className="h-full"
-              src={String(pokemon.sprites.other?.dream_world?.front_default)}
+              src={String(data.sprites.other?.dream_world?.front_default)}
             />
           </div>
           <div className="flex gap-2 flex-wrap justify-center">
-            {pokemon.types.map(({ type }) => (
+            {data.types.map(({ type }) => (
               <Badge key={type.name} variant="default">
                 {type.name}
               </Badge>
@@ -64,7 +76,7 @@ export default function PokemonDialog() {
               className="max-h-24 overflow-scroll self-start w-full"
             >
               <ul className="list-disc">
-                {pokemon.abilities.map(({ ability }) => (
+                {data.abilities.map(({ ability }) => (
                   <li key={ability.name}>
                     <a
                       href={ability.url}
@@ -82,7 +94,7 @@ export default function PokemonDialog() {
               className="max-h-24 overflow-scroll self-start w-full"
             >
               <ul className="list-disc">
-                {pokemon.moves.map(({ move }) => (
+                {data.moves.map(({ move }) => (
                   <li key={move.name}>
                     <a
                       href={move.url}
@@ -100,7 +112,7 @@ export default function PokemonDialog() {
               className="max-h-24 overflow-scroll self-start w-full"
             >
               <ul className="list-disc">
-                {pokemon.forms.map(({ name, url }) => (
+                {data.forms.map(({ name, url }) => (
                   <li key={name}>
                     <a href={url} target="_blank" rel="noopener noreferrer">
                       {name}

--- a/app/routes/home/pokemonList.tsx
+++ b/app/routes/home/pokemonList.tsx
@@ -1,14 +1,10 @@
 import {
   data,
-  useFetcher,
   useLoaderData,
-  useSearchParams,
   type ShouldRevalidateFunctionArgs,
 } from 'react-router';
-import { SEARCH_POKEMON_FORM_KEY, type clientAction } from './home';
 import PokemonCard from '~/components/ui/pokemonCard';
-import Loading from '~/components/ui/Loading';
-import { getPokemonImageSrc } from '~/lib/utils';
+import { getPokemonImageSrc, wait } from '~/lib/utils';
 import { getPaginatedPokemonList } from '~/services/apiClient';
 import PokemonPagination from '~/components/ui/pokemonPagination';
 import type { Route } from './+types/pokemonList';
@@ -22,6 +18,8 @@ export async function clientLoader({ request }: Route.ClientLoaderArgs) {
   }
 
   try {
+    await wait(1000);
+
     const data = await getPaginatedPokemonList(offset);
     return data;
   } catch (error) {
@@ -43,18 +41,13 @@ export function shouldRevalidate({
 }
 
 export default function PokemonList() {
-  const fetcher = useFetcher<typeof clientAction>({
-    key: SEARCH_POKEMON_FORM_KEY,
-  });
-  const { results, previous, next } = useLoaderData<typeof clientLoader>();
-  const pokemonList = fetcher.data ?? results;
-  const shouldShowPagination = !fetcher.data
+  const {
+    results: pokemonList,
+    previous,
+    next,
+  } = useLoaderData<typeof clientLoader>();
   const nextOffset = getOffset(next);
   const prevOffset = getOffset(previous);
-
-  if (fetcher.state === 'submitting') {
-    return <Loading />;
-  }
 
   if (!pokemonList || pokemonList.length === 0) {
     return <p>Pokemon not found</p>;
@@ -62,7 +55,7 @@ export default function PokemonList() {
 
   return (
     <>
-      {shouldShowPagination && <PokemonPagination next={nextOffset} prev={prevOffset} />}
+      <PokemonPagination next={nextOffset} prev={prevOffset} />
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 pb-4 pt-4">
         {pokemonList.map((pokemon) => (
           <PokemonCard
@@ -72,7 +65,7 @@ export default function PokemonList() {
           />
         ))}
       </div>
-      {shouldShowPagination && <PokemonPagination next={nextOffset} prev={prevOffset} />}
+      <PokemonPagination next={nextOffset} prev={prevOffset} />
     </>
   );
 }


### PR DESCRIPTION
### Summary
Improve the Pokémon search flow by migrating from a POST-based fetcher action to a GET-based URL-driven search. This streamlines navigation, enables sharable/refreshable search URLs, and simplifies state management. Also adds a dedicated `PokemonSearchBar` component and consolidates the Pokémon detail route to read from query params.

### Key Changes
- New `app/components/ui/pokemonSearchBar.tsx`:
  - Reusable search form using `<Form method="GET" />`.
  - Keeps input value in sync with `q` query param via `useSearchParams`.
- Update `app/routes.ts`:
  - Replace `route('/pokemon/:name', 'routes/home/pokemonDialog.tsx')` with `route('/pokemon', 'routes/home/pokemon.tsx')`.
  - Detail page is now driven by `?q=<nameOrId>` instead of a path param.
- Revamp `app/routes/home/home.tsx`:
  - Remove `clientAction` and `fetcher` usage.
  - Use `useNavigation()` to show a global loading state.
  - Render new `PokemonSearchBar` pointing to `/pokemon`.
- Rename and refactor `app/routes/home/pokemonDialog.tsx` → `app/routes/home/pokemon.tsx`:
  - Add `clientLoader` that reads `q` from URL, fetches the Pokémon, and returns:
    - `null` when no `q` is provided (no dialog).
    - A data object on success.
    - An `{ error: string }` shape on not found.
  - Remove back-navigation side effect; dialog opens by default and is controlled by route presence.
- Simplify `app/routes/home/pokemonList.tsx`:
  - Remove dependency on `fetcher` and form state.
  - Loader remains paginated; add a small artificial delay via `wait(1000)` for visible loading during demo.
  - Always show `PokemonPagination` above and below the grid.
- Editor settings: enforce Prettier as default formatter for JS/TS/TSX.

### Why
- URL-based search (GET with `?q=`) improves usability:
  - Sharable links and browser-native navigation (back/forward, refresh).
  - Better alignment with web conventions for search.
  - Fewer moving parts vs POST + fetcher state management.
- Clear separation of concerns:
  - List page handles pagination only.
  - Detail dialog is route-driven and fetches its own data based on `q`.

### UX Improvements
- Search input persists the last `q` via `defaultValue` + `useSearchParams`.
- Loading feedback during route transitions using `useNavigation()` and a centralized `<Loading />`.
- Consistent pagination placement.
- Error message returned directly in the detail route when a Pokémon isn’t found.

### Technical Notes
- `pokemon.tsx` client loader logic:
  - Reads `q` from `request.url`.
  - Returns `null` when `q` is missing to avoid rendering the dialog.
  - Returns `{ error: string }` on failures rather than throwing, allowing inline error UI.
- Artificial delays (`wait(1000)`) in `pokemonList` and `pokemon` for demo-only loading visuals; safe to adjust/remove later.
- Dialog no longer manipulates history on close; navigation is left to route changes, which avoids unexpected back stack behavior.

### Screenshots/GIFs (optional)
- Home with search bar
- Loading state after submit
- Pokémon detail dialog with types, abilities, moves, forms

### How to Test
1) List page and pagination
- Navigate to `/`.
- Verify list renders with pagination controls above and below the grid.
- Click Next/Prev and confirm the list updates and URL reflects `?offset=`.

2) Search flow (GET)
- From `/`, enter a term (e.g., `pikachu`) and hit Search.
- You should be routed to `/pokemon?q=pikachu` and see the dialog open with details.
- Refresh the page and confirm the same state loads.
- Copy/share the URL and confirm it reproduces the state.

3) Not found
- Go to `/pokemon?q=does-not-exist`.
- Confirm a friendly not found message is shown inside the dialog area.

4) Empty query
- Go to `/pokemon` with no `q`.
- Confirm no dialog is shown.

### Accessibility
- Search input has `aria-label`.
- Dialog includes `aria-description` referencing the current Pokémon.
- Pagination and content maintain semantic structure.

### Performance
- Uses route loaders and URL state; no client-side fetcher indirection for search.
- Minor demo-only delays; can be removed to improve responsiveness when desired.

### Breaking Changes
- Direct links of the form `/pokemon/:name` are replaced by `/pokemon?q=:name`.
  - Update any external links accordingly.

### Follow-ups (nice-to-have)
- Add close button to dialog that navigates back to the list route.
- Consider debounced typeahead for search.
- Extract shared loader delay into an env-guarded flag so it’s disabled in production builds.

—
Related PR: https://github.com/raulingg/react-pokeapp/pull/1